### PR TITLE
Add support for filtering restricted posts from The Loop

### DIFF
--- a/User-Specific-Content.php
+++ b/User-Specific-Content.php
@@ -115,6 +115,10 @@ class bainternet_U_S_C {
 			/* hook the_excerpt to filter users */
 			add_filter('the_excerpt',array($this,'User_specific_content_filter'),20);
 		}
+		if ($options['run_on_the_loop']){
+			/* hook pre_get_posts to filter posts by restrictions */
+			add_action('pre_get_posts', array($this, 'User_specific_loop_filter'));
+		}
 		//allow other filters
 		do_action('User_specific_content_filter_add',$this);
 	}
@@ -402,6 +406,39 @@ class bainternet_U_S_C {
 
 		return $content;
 	}
+	
+	public function User_specific_loop_filter($query){
+
+    if ( is_main_query() && !is_admin() && !is_singular() ) {
+      global $current_user;
+      get_currentuserinfo();
+  
+      $args = array(
+        'relation' => 'OR',
+        array(
+          'key' => 'U_S_C_roles',
+          'compare' => 'NOT EXISTS'
+        )
+      );
+  
+      if ( !empty( $current_user ) ) {
+        $roles = $current_user->roles;
+  
+        foreach ($roles as $r) {
+          $args[] = array(
+            'key' => 'U_S_C_roles',
+            'value' => $r,
+            'compare' => 'LIKE'
+          );
+        }
+  
+      }
+  
+      $query->set('meta_query', $args);
+  
+      return $query;
+    }
+  }
 
 	/************************
 	* helpers

--- a/config/main_plugin_fields.php
+++ b/config/main_plugin_fields.php
@@ -42,6 +42,16 @@ $p->add_field(array(
     )
 );
 
+$p->add_field(array(
+    'label'   => __('Filter posts from The Loop?','bauspc'),
+    'std'     => false,
+    'id'      => 'run_on_the_loop',
+    'type'    => 'checkbox',
+    'section' => $setting,
+    'desc'    => __('(check to stop posts appearing on archive / tags / category pages default unchecked)','bauspc')
+    )
+);
+
 $setting2 = $p->add_section(array(
 	'option_group'      =>  'U_S_C',
 	'sanitize_callback' => null,


### PR DESCRIPTION
This was developed to stop restricted posts appearing in category and archive listing where they are unable to see the post.
Visiting the url directly still displays the blocked message.
